### PR TITLE
modification for passing openbmc test automation

### DIFF
--- a/user_channel/passwd_mgr.cpp
+++ b/user_channel/passwd_mgr.cpp
@@ -102,13 +102,13 @@ int PasswdMgr::updateUserEntry(const std::string& userName,
 
 void PasswdMgr::checkAndReload(void)
 {
-    std::time_t updatedTime = getUpdatedFileTime();
-    if (fileLastUpdatedTime != updatedTime && updatedTime != -1)
-    {
+    //std::time_t updatedTime = getUpdatedFileTime();
+    //if (fileLastUpdatedTime != updatedTime && updatedTime != -1)
+    //{
         log<level::DEBUG>("Reloading password map list");
         passwdMapList.clear();
         initPasswordMap();
-    }
+    //}
 }
 
 int PasswdMgr::encryptDecryptData(bool doEncrypt, const EVP_CIPHER* cipher,

--- a/user_channel/user_mgmt.cpp
+++ b/user_channel/user_mgmt.cpp
@@ -1458,13 +1458,13 @@ void UserAccess::deleteUserIndex(const size_t& usrIdx)
 
 void UserAccess::checkAndReloadUserData()
 {
-    std::time_t updateTime = getUpdatedFileTime();
-    if (updateTime != fileLastUpdatedTime || updateTime == -EIO)
-    {
+    //std::time_t updateTime = getUpdatedFileTime();
+    //if (updateTime != fileLastUpdatedTime || updateTime == -EIO)
+    //{
         std::fill(reinterpret_cast<uint8_t*>(&usersTbl),
                   reinterpret_cast<uint8_t*>(&usersTbl) + sizeof(usersTbl), 0);
         readUserData();
-    }
+    //}
     return;
 }
 


### PR DESCRIPTION
1. Get updated user information everytime by skipping the user information file timestamp check for the test_ipmi_user.robot.

Signed-off-by: kfting <kfting@nuvoton.com>