### PR TITLE
smbiosmdrv2handler: add new ipmi oem cmd to support smbios feature

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -112,6 +112,7 @@ libipmi20_la_SOURCES = \
 	read_fru_data.cpp \
 	sensordatahandler.cpp \
 	user_channel/channelcommands.cpp \
+	smbiosmdrv2handler.cpp \
 	$(libipmi20_la_TRANSPORTOEM) \
 	$(libipmi20_BUILT_LIST)
 

--- a/oemcommands.hpp
+++ b/oemcommands.hpp
@@ -1,0 +1,31 @@
+/*
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#pragma once
+
+#include <ipmid/api-types.hpp>
+
+namespace ipmi
+{
+namespace intel
+{
+static constexpr NetFn netFnApp = netFnOemEight;
+namespace app
+{
+static constexpr Cmd cmdMdrIIGetMboxSharedMem = 0x3e;
+} // namespace app
+} // namespace intel
+} // namespace ipmi

--- a/smbiosmdrv2handler.cpp
+++ b/smbiosmdrv2handler.cpp
@@ -1,0 +1,170 @@
+/*
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#include "smbiosmdrv2handler.hpp"
+
+#include <ipmid/api.hpp>
+#include <ipmid/utils.hpp>
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/log.hpp>
+#include <string>
+#include <xyz/openbmc_project/Common/error.hpp>
+#include <fstream>
+
+std::unique_ptr<MDRV2> mdrv2 = nullptr;
+
+void register_netfn_smbiosmdrv2_functions() __attribute__((constructor));
+
+void SharedMemoryArea::Initialize(uint32_t addr, uint32_t areaSize)
+{
+    int memDriver = 0;
+
+    // open mem driver for the system memory access
+    memDriver = open("/dev/mem", O_RDONLY);
+    if (memDriver < 0)
+    {
+        phosphor::logging::log<phosphor::logging::level::ERR>(
+            "Cannot access mem driver");
+        throw std::system_error(EIO, std::generic_category());
+    }
+
+    // map the system memory
+    vPtr = mmap(NULL,                       // where to map to: don't mind
+                areaSize,                   // how many bytes ?
+                PROT_READ,                  // want to read and write
+                MAP_SHARED,                 // no copy on write
+                memDriver,                  // handle to /dev/mem
+                physicalAddr);              // hopefully the Text-buffer :-)
+
+    close(memDriver);
+    if (vPtr == MAP_FAILED)
+    {
+        phosphor::logging::log<phosphor::logging::level::ERR>(
+            "Failed to map share memory");
+        throw std::system_error(EIO, std::generic_category());
+    }
+    size = areaSize;
+    physicalAddr = addr;
+}
+
+void MDRV2::timeoutHandler()
+{
+    mdrv2->area.reset(nullptr);
+}
+
+void MDRV2::RestartMDRV2()
+{
+    std::shared_ptr<sdbusplus::asio::connection> bus = getSdBus();
+    sdbusplus::message::message method =
+        bus->new_method_call(SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH, SYSTEMD_INTERFACE,
+                             "RestartUnit");
+
+    method.append(SMBIOS_MDRV2_SERVICE);
+    method.append("replace");
+
+    bus->call_noreply(method);
+}
+
+bool MDRV2::storeDatatoFlash(MDRSMBIOSHeader *mdrHdr, uint8_t *data)
+{
+    std::ofstream smbiosFile(mdrType2File,
+                             std::ios_base::binary | std::ios_base::trunc);
+    if (!smbiosFile.good())
+    {
+        phosphor::logging::log<phosphor::logging::level::ERR>(
+            "Write data from flash error - Open MDRV2 table file failure");
+        return false;
+    }
+
+    try
+    {
+        smbiosFile.write(reinterpret_cast<char *>(mdrHdr),
+                         sizeof(MDRSMBIOSHeader));
+        smbiosFile.write(reinterpret_cast<char *>(data), mdrHdr->dataSize);
+    }
+    catch (std::ofstream::failure &e)
+    {
+        phosphor::logging::log<phosphor::logging::level::ERR>(
+            "Write data from flash error - write data error",
+            phosphor::logging::entry("ERROR=%s", e.what()));
+        return false;
+    }
+
+    return true;
+}
+
+/** @brief implements mdr2 get mbox shared mem command
+ *
+ *  @returns IPMI completion code
+ */
+ipmi::RspType<> cmd_mdr2_get_mbox_shared_mem()
+{
+    std::shared_ptr<sdbusplus::asio::connection> bus = getSdBus();
+    std::string service = ipmi::getService(*bus, mdrv2Interface, mdrv2Path);
+
+    if (mdrv2 == nullptr)
+    {
+        mdrv2 = std::make_unique<MDRV2>();
+    }
+
+    try
+    {
+        mdrv2->area =
+            std::make_unique<SharedMemoryArea>(MboxAddress, MboxLength);
+    }
+    catch (const std::system_error &e)
+    {
+        return ipmi::responseUnspecifiedError();
+    }
+
+    std::vector<std::uint8_t> results(MboxLength);
+    std::memcpy(results.data(), mdrv2->area->vPtr, MboxLength);
+
+    mdrv2->area.reset(nullptr);
+    MDRSMBIOSHeader mdr2Smbios;
+    mdr2Smbios.mdrType = mdrTypeII;
+    mdr2Smbios.dirVer = mdrv2->smbiosDir.dir[0].common.dataVersion;
+    mdr2Smbios.timestamp = mdrv2->smbiosDir.dir[0].common.timestamp;
+    mdr2Smbios.dataSize = mdrv2->smbiosDir.dir[0].common.size;
+
+    if (access(smbiosPath, 0) == -1)
+    {
+        int flag = mkdir(smbiosPath, S_IRWXU);
+        if (flag != 0)
+        {
+            phosphor::logging::log<phosphor::logging::level::ERR>(
+                "create folder failed for writting smbios file");
+        }
+    }
+    if (!mdrv2->storeDatatoFlash(&mdr2Smbios, results.data()))
+    {
+        phosphor::logging::log<phosphor::logging::level::ERR>(
+            "MDR2 Store data to flash failed");
+        return ipmi::responseDestinationUnavailable();
+    }
+
+    mdrv2->RestartMDRV2();
+    return ipmi::responseSuccess();
+}
+
+void register_netfn_smbiosmdrv2_functions()
+{
+    // <Get Mailbox Shared Memory>
+    ipmi::registerHandler(ipmi::prioOpenBmcBase, ipmi::intel::netFnApp,
+                          ipmi::intel::app::cmdMdrIIGetMboxSharedMem, ipmi::Privilege::Operator,
+                          cmd_mdr2_get_mbox_shared_mem);
+    return;
+}

--- a/smbiosmdrv2handler.hpp
+++ b/smbiosmdrv2handler.hpp
@@ -1,0 +1,316 @@
+/*
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#pragma once
+
+#include <ipmid/api.h>
+#include <sys/mman.h>
+
+#include <oemcommands.hpp>
+#include <sdbusplus/timer.hpp>
+#include <phosphor-logging/log.hpp>
+#include <sdbusplus/message/types.hpp>
+
+static constexpr const uint32_t MboxAddress = 0xF0848000;
+static constexpr const uint32_t MboxLength  = 0x4000;
+
+constexpr auto SYSTEMD_SERVICE = "org.freedesktop.systemd1";
+constexpr auto SYSTEMD_OBJ_PATH = "/org/freedesktop/systemd1";
+constexpr auto SYSTEMD_INTERFACE = "org.freedesktop.systemd1.Manager";
+constexpr auto SMBIOS_MDRV2_SERVICE = "smbios-mdrv2.service";
+
+static constexpr const char *mdrType2File = "/var/lib/smbios/smbios2";
+static constexpr const char *smbiosPath = "/var/lib/smbios";
+static constexpr const size_t msgPayloadSize =
+    1024 * 60; // Total size will transfer for smbios table
+static constexpr const size_t mdriiSMSize = 0x00100000;
+
+static constexpr const uint16_t smbiosAgentId =
+    0x0101; // Agent ID for smbios entry
+static constexpr const int firstAgentIndex = 1;
+
+static constexpr const uint8_t maxDirEntries = 4; // Maximum directory entries
+static constexpr const uint32_t mdr2SMSize =
+    0x00100000; // Size of VGA share memory
+static constexpr const uint32_t mdr2SMBaseAddress =
+    0x9FF00000; // Base address of VGA share memory
+
+static constexpr const uint8_t mdrTypeII = 2; // MDR V2 type
+
+static constexpr const uint8_t mdr2Version = 2;        // MDR V2 versoin
+static constexpr const uint8_t smbiosAgentVersion = 1; // Agent version of
+                                                       // smbios
+
+static constexpr const uint32_t pageMask =
+    0xf000; // To make data become n times of page
+static constexpr const int smbiosDirIndex = 0; // SMBIOS directory index
+
+static constexpr const uint32_t smbiosTableVersion =
+    15; // Version of smbios table
+static constexpr const uint32_t smbiosTableTimestamp =
+    0x45464748; // Time stamp when smbios table created
+static constexpr const size_t smbiosSMMemoryOffset =
+    0; // Offset of VGA share memory
+static constexpr const size_t smbiosSMMemorySize =
+    16 * 1024; // Total size of VGA share memory
+static constexpr const size_t smbiosTableStorageSize =
+    16 * 1024; // Total size of smbios table
+static constexpr const uint32_t defaultTimeout = 200;
+static constexpr const uint8_t sysClock = 100;
+static constexpr const int lastAgentIndex = -1;
+static constexpr const uint16_t lastAgentId = 0xFFFF;
+constexpr const uint32_t invalidChecksum = 0xffffffff;
+constexpr const char *dbusProperties = "org.freedesktop.DBus.Properties";
+constexpr const char *mdrv2Path = "/xyz/openbmc_project/Smbios/MDR_V2";
+constexpr const char *mdrv2Interface = "xyz.openbmc_project.Smbios.MDR_V2";
+
+enum class MDR2SMBIOSStatusEnum
+{
+    mdr2Init = 0,
+    mdr2Loaded = 1,
+    mdr2Updated = 2,
+    mdr2Updating = 3
+};
+
+enum class DirDataRequestEnum
+{
+    dirDataNotRequested = 0x00,
+    dirDataRequested = 0x01
+};
+
+enum MDR2DirLockEnum
+{
+    mdr2DirUnlock = 0,
+    mdr2DirLock = 1
+};
+
+#pragma pack(push)
+#pragma pack(1)
+
+
+struct MDRSMBIOSHeader
+{
+    uint8_t dirVer;
+    uint8_t mdrType;
+    uint32_t timestamp;
+    uint32_t dataSize;
+};
+
+struct DataIdStruct
+{
+    uint8_t dataInfo[16];
+};
+
+struct Mdr2DirEntry
+{
+    DataIdStruct id;
+    uint32_t size;
+    uint32_t dataSetSize;
+    uint32_t dataVersion;
+    uint32_t timestamp;
+};
+
+struct Mdr2DirLocalStruct
+{
+    Mdr2DirEntry common;
+    MDR2SMBIOSStatusEnum stage;
+    MDR2DirLockEnum lock;
+    uint16_t lockHandle;
+    uint32_t xferBuff;
+    uint32_t xferSize;
+    uint32_t maxDataSize;
+    uint8_t *dataStorage;
+};
+
+struct Mdr2DirStruct
+{
+    uint8_t agentVersion;
+    uint8_t dirVersion;
+    uint8_t dirEntries;
+    uint8_t status; // valid / locked / etc
+    uint8_t remoteDirVersion;
+    uint16_t sessionHandle;
+    Mdr2DirLocalStruct dir[maxDirEntries];
+};
+
+// Three members include dataSetSize, dataVersion and timestamp
+static constexpr const size_t syncDirCommonSize = 3;
+
+// ====================== MDR II Pull Command Structures ======================
+struct MDRiiGetDataInfoRequest
+{
+    uint16_t agentId;
+    DataIdStruct dataSetInfo;
+};
+
+// MDR II data set information inquiry response
+struct MDRiiGetDataInfoResponse
+{
+    uint8_t mdrVersion;
+    DataIdStruct dataSetId;
+    uint8_t validFlag;
+    uint32_t dataLength;
+    uint32_t dataVersion;
+    uint32_t timeStamp;
+};
+
+// ====================== MDR II Push Command Structures ======================
+// MDR II Client send data set info offer response
+struct MDRiiOfferDataInfoResponse
+{
+    DataIdStruct dataSetInfo;
+};
+
+// MDR II Push Agent send data set info command
+struct MDRiiSendDataInfoRequest
+{
+    uint16_t agentId;
+    DataIdStruct dataSetInfo;
+    uint8_t validFlag;
+    uint32_t dataLength;
+    uint32_t dataVersion; // Roughly equivalent to the "file name"
+    uint32_t
+        timeStamp; // More info on the identity of this particular set of data
+};
+
+// MDR II Pull Agent lock data set command
+struct MDRiiLockDataRequest
+{
+    uint16_t agentId;
+    DataIdStruct dataSetInfo;
+    uint16_t timeout;
+};
+
+// MDR II Pull Agent lock data set response
+struct MDRiiLockDataResponse
+{
+    uint8_t mdrVersion;
+    uint16_t lockHandle;
+    uint32_t dataLength;
+    uint32_t xferAddress;
+    uint32_t xferLength;
+};
+
+// MDR II Push Agent send data start command
+struct MDRiiDataStartRequest
+{
+    uint16_t agentId;
+    DataIdStruct dataSetInfo;
+    uint32_t dataLength;
+    uint32_t xferAddress;
+    uint32_t xferLength;
+    uint16_t timeout;
+};
+
+// MDR II Client send data start response
+struct MDRiiDataStartResponse
+{
+    uint8_t xferStartAck;
+    uint16_t sessionHandle;
+};
+
+// MDR II
+struct MDRiiDataDoneRequest
+{
+    uint16_t agentId;
+    uint16_t lockHandle;
+};
+
+#pragma pack(pop)
+
+class SharedMemoryArea
+{
+  public:
+    SharedMemoryArea(uint32_t addr, uint32_t areaSize) :
+        vPtr(nullptr), physicalAddr(addr), size(areaSize)
+    {
+        Initialize(addr, areaSize);
+    }
+
+    ~SharedMemoryArea()
+    {
+        if ((vPtr != nullptr) && (vPtr != MAP_FAILED))
+        {
+            if (0 != munmap(vPtr, size))
+            {
+                phosphor::logging::log<phosphor::logging::level::ERR>(
+                    "Ummap share memory failed");
+            }
+        }
+    }
+
+    void *vPtr;
+
+  private:
+    uint32_t physicalAddr;
+    uint32_t size;
+
+    void Initialize(uint32_t addr, uint32_t areaSize);
+};
+
+class MDRV2
+{
+  public:
+    MDRV2()
+    {
+        timer =
+            std::make_unique<phosphor::Timer>([&](void) { timeoutHandler(); });
+    }
+
+    void RestartMDRV2();
+    bool storeDatatoFlash(MDRSMBIOSHeader *mdrHdr, uint8_t *data);
+    void timeoutHandler();
+
+    Mdr2DirStruct smbiosDir{smbiosAgentVersion,
+                            1,
+                            1,
+                            1,
+                            0,
+                            0,
+                            {40,
+                             41,
+                             42,
+                             43,
+                             44,
+                             45,
+                             46,
+                             47,
+                             48,
+                             49,
+                             50,
+                             51,
+                             52,
+                             53,
+                             54,
+                             0x42,
+                             smbiosSMMemorySize,
+                             smbiosTableStorageSize,
+                             smbiosTableVersion,
+                             smbiosTableTimestamp,
+                             MDR2SMBIOSStatusEnum::mdr2Init,
+                             MDR2DirLockEnum::mdr2DirUnlock,
+                             0,
+                             smbiosSMMemoryOffset,
+                             smbiosSMMemorySize,
+                             smbiosTableStorageSize,
+                             smbiosTableStorage}};
+    std::unique_ptr<SharedMemoryArea> area;
+    std::unique_ptr<phosphor::Timer> timer;
+
+  private:
+    uint8_t lockIndex = 0;
+    uint8_t smbiosTableStorage[smbiosTableStorageSize];
+};


### PR DESCRIPTION
Tested:
1. Before verify smbios feature, execute "xfer_mbox_mem" utility at RunBMC Host side
2. sudo ./xfer_mbox_mem --command update --interface ipmipci --image DMI --sig xfer_mbox_mem
3. Verify "Hardware status" on WebUI should be showed Bios/CPU/DIMM informations of Host

Signed-off-by: Tim Lee <timlee660101@gmail.com>