### PR TITLE
phosphor-ipmi-host: Do not use size_t in struct MetaPassStruct

### DIFF
--- a/user_channel/passwd_mgr.cpp
+++ b/user_channel/passwd_mgr.cpp
@@ -51,11 +51,11 @@ struct MetaPassStruct
 {
     char signature[10];
     unsigned char reseved[2];
-    size_t hashSize;
-    size_t ivSize;
-    size_t dataSize;
-    size_t padSize;
-    size_t macSize;
+    unsigned int hashSize;
+    unsigned int ivSize;
+    unsigned int dataSize;
+    unsigned int padSize;
+    unsigned int macSize;
 };
 
 using namespace phosphor::logging;


### PR DESCRIPTION
	Note: size_t is 8 bytes in aarch64

Signed-off-by: Medad <ctcchien@nuvoton.com>